### PR TITLE
Fix PostCSS plugin configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,10 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+// Tailwind CSS requires the standard PostCSS setup with the Tailwind and
+// Autoprefixer plugins. The previous configuration referenced
+// `@tailwindcss/postcss`, which isn't a valid PostCSS plugin and causes the
+// build to fail.
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- fix PostCSS config to use `tailwindcss` and `autoprefixer`

## Testing
- `npm run lint` *(fails: next not found)*